### PR TITLE
Imp: Allow custom queue sizes for sub and pub in action client/server

### DIFF
--- a/actionlib/src/actionlib/action_client.py
+++ b/actionlib/src/actionlib/action_client.py
@@ -503,8 +503,10 @@ class ActionClient:
     ## example, the "goal" topic should occur under ns/goal
     ##
     ## @param ActionSpec The *Action message type.  The ActionClient
+    ## @param sub_queue_size * int. Length of the subscriber queue, will be used if set, falls back to the ros paramter
+    ## @param pub_queue_size * int. Length of the publisher queue, will be used if set, falls back to the ros paramter
     ## will grab the other message types from this type.
-    def __init__(self, ns, ActionSpec):
+    def __init__(self, ns, ActionSpec,  sub_queue_size=None, pub_queue_size=None):
         self.ns = ns
         self.last_status_msg = None
 
@@ -518,8 +520,8 @@ class ActionClient:
         except AttributeError:
             raise ActionException("Type is not an action spec: %s" % str(ActionSpec))
 
-        self.pub_queue_size = rospy.get_param('actionlib_client_pub_queue_size', 10)
-        if self.pub_queue_size < 0:
+        self.pub_queue_size = pub_queue_size or rospy.get_param('actionlib_client_pub_queue_size', 10)
+        if pub_queue_size is None and self.pub_queue_size < 0:
             self.pub_queue_size = 10
         self.pub_goal = rospy.Publisher(rospy.remap_name(ns) + '/goal', self.ActionGoal, queue_size=self.pub_queue_size)
         self.pub_cancel = rospy.Publisher(rospy.remap_name(ns) + '/cancel', GoalID, queue_size=self.pub_queue_size)

--- a/actionlib/src/actionlib/action_server.py
+++ b/actionlib/src/actionlib/action_server.py
@@ -61,7 +61,9 @@ class ActionServer:
     ## @param  goal_cb A goal callback to be called when the ActionServer receives a new goal over the wire
     ## @param  cancel_cb A cancel callback to be called when the ActionServer receives a new cancel request over the wire
     ## @param  auto_start A boolean value that tells the ActionServer wheteher or not to start publishing as soon as it comes up. THIS SHOULD ALWAYS BE SET TO FALSE TO AVOID RACE CONDITIONS and start() should be called after construction of the server.
-    def __init__(self, ns,  ActionSpec, goal_cb, cancel_cb=nop_cb, auto_start=True):
+    ## @param sub_queue_size The queue size of subscribers, if not set use the param actionlib_server_sub_queue_size, default to -1
+    ## @param pub_queue_size The queue size of publisher, if not set use the param actionlib_server_pub_queue_size, default to 50
+    def __init__(self, ns,  ActionSpec, goal_cb, cancel_cb=nop_cb, auto_start=True, sub_queue_size=None, pub_queue_size=None):
         self.ns = ns
 
         try:
@@ -100,6 +102,9 @@ class ActionServer:
 
         self.started = False
 
+        self._pub_queue_size = pub_queue_size
+        self._sub_queue_size = sub_queue_size
+
         if self.auto_start:
             rospy.logwarn("You've passed in true for auto_start to the python action server, you should always pass "
                           "in false to avoid race conditions.")
@@ -135,14 +140,14 @@ class ActionServer:
 
     ## @brief  Initialize all ROS connections and setup timers
     def initialize(self):
-        self.pub_queue_size = rospy.get_param('actionlib_server_pub_queue_size', 50)
+        self.pub_queue_size = self._pub_queue_size or rospy.get_param('actionlib_server_pub_queue_size', 50)
         if self.pub_queue_size < 0:
             self.pub_queue_size = 50
         self.status_pub = rospy.Publisher(rospy.remap_name(self.ns)+"/status", GoalStatusArray, latch=True, queue_size=self.pub_queue_size)
         self.result_pub = rospy.Publisher(rospy.remap_name(self.ns)+"/result", self.ActionResult, queue_size=self.pub_queue_size)
         self.feedback_pub = rospy.Publisher(rospy.remap_name(self.ns)+"/feedback", self.ActionFeedback, queue_size=self.pub_queue_size)
 
-        self.sub_queue_size = rospy.get_param('actionlib_server_sub_queue_size', -1)
+        self.sub_queue_size = self._sub_queue_size or rospy.get_param('actionlib_server_sub_queue_size', -1)
         if self.sub_queue_size < 0:
             self.sub_queue_size = None
         self.goal_sub = rospy.Subscriber(rospy.remap_name(self.ns)+"/goal", self.ActionGoal, callback=self.internal_goal_callback, queue_size=self.sub_queue_size)


### PR DESCRIPTION
Allow to pass arguments to constructor to overwrite the global queue sizes for publishers and subscribers. If the arguments are given they will always be used. If not the rosparams and their defaults are used.

This should not affect any existing implementation.

I bring up the alternative solution:

`rospy.get_param(rospy.search_param("actionlib_client_pub_queue_size:), 10)`

The problem here is that a pub queue size of -1 will still default to 10.
So i would either need to set it to a very high value (e.g. 10000) or create a new parameter to set it to -1.

However if somebody finds a good reason to do it like this i'm fine with it.