### PR TITLE
Imp: Catch BaseException in SimpleActionServer

### DIFF
--- a/actionlib/src/actionlib/simple_action_server.py
+++ b/actionlib/src/actionlib/simple_action_server.py
@@ -293,7 +293,7 @@ class SimpleActionServer:
                                       "This is a bug in your ActionServer implementation. Fix your code!  " +
                                       "For now, the ActionServer will set this goal to aborted")
                         self.set_aborted(None, "No terminal state was set.")
-                except Exception as ex:
+                except BaseException as ex:
                     rospy.logerr("Exception in your execute callback: %s\n%s", str(ex),
                                  traceback.format_exc())
                     self.set_aborted(None, "Exception in execute callback: %s" % str(ex))


### PR DESCRIPTION
We have seen some cases where the execute_callback has an uncaught failure which makes the executeLoop and thereby self.execute_thread terminate. This goes unrecognized by the client as the server keeps publishing the latest status to the status topic. With this change we extend the handling of Exceptions to all BaseExceptions that are not inherited from the Exception class.